### PR TITLE
fast UUID fix

### DIFF
--- a/src/arkparse/parsing/_base_value_parser.py
+++ b/src/arkparse/parsing/_base_value_parser.py
@@ -1,6 +1,6 @@
 import struct
 from typing import List
-from uuid import UUID
+from uuid import UUID, SafeUUID
 
 from ._binary_reader_base import BinaryReaderBase
 from arkparse.logging import ArkSaveLogger
@@ -24,6 +24,7 @@ def _fast_uuid_from_bytes(b: bytes) -> UUID:
     # This is ~3-4x faster than UUID(bytes=b)
     u = object.__new__(UUID)
     object.__setattr__(u, 'int', int.from_bytes(b, 'big'))
+    object.__setattr__(u, 'is_safe', SafeUUID.unknown)
     return u
     
 class BaseValueParser(BinaryReaderBase):

--- a/src/arkparse/saves/save_connection.py
+++ b/src/arkparse/saves/save_connection.py
@@ -1,7 +1,7 @@
 import sqlite3
 import sys
 import uuid
-from uuid import UUID
+from uuid import UUID, SafeUUID
 from pathlib import Path
 from typing import Collection, Optional, Dict, List, Tuple
 from concurrent.futures import ThreadPoolExecutor
@@ -21,6 +21,7 @@ def _fast_uuid_from_bytes(b: bytes) -> UUID:
     """Create UUID from bytes, bypassing __init__ validation for speed."""
     u = object.__new__(UUID)
     object.__setattr__(u, 'int', int.from_bytes(b, 'big'))
+    object.__setattr__(u, 'is_safe', SafeUUID.unknown)
     return u
 
 


### PR DESCRIPTION
* Added is_safe attribute to fast UUID object creation (allows to use Python's multiprocessing serialization).